### PR TITLE
OC-62 - Add links for authors names

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -93,3 +93,6 @@ hr.octopus-separator { height: 30px; background: url('../images/separatorChain.p
 .pubChainContainer.minimised .pubItem { opacity: 0; }
 
 .form-group { margin-bottom: 35px; }
+
+/* Authors list links */
+.authors-list .authors-list-items { display: inline-flex; }

--- a/views/partials/authorsList.hbs
+++ b/views/partials/authorsList.hbs
@@ -6,7 +6,7 @@
       {{/if}}
         <span class="authors-list-item">
           {{#if this.orcid}}
-            <a href="/usrs/view/{{this.orchid}}">{{this.name}}</a>
+            <a href="/users/view/{{this.orchid}}">{{this.name}}</a>
           {{else}}
             {{this.name}}
           {{/if}}

--- a/views/partials/authorsList.hbs
+++ b/views/partials/authorsList.hbs
@@ -1,0 +1,16 @@
+<span class="authors-list">
+  <span class="authors-list-items">
+    {{#each authors}}
+      {{#if @index}}
+        <span class="authors-list-item-separator">,&nbsp;</span>
+      {{/if}}
+        <span class="authors-list-item">
+          {{#if this.orcid}}
+            <a href="/usrs/view/{{this.orchid}}">{{this.name}}</a>
+          {{else}}
+            {{this.name}}
+          {{/if}}
+        </span>
+    {{/each}}
+  </span>
+</span>

--- a/views/partials/publications/body/edit.hbs
+++ b/views/partials/publications/body/edit.hbs
@@ -5,7 +5,7 @@
 
       <h1><span class="text-accent">{{publication.type}}:</span> {{publication.title}}</h1>
 
-      <p>Authors: {{publication.authors}}</p>
+      <p>Authors: {{> authorsList authors=publication.authors}}</p>
       <p>Date added: {{formatDate publication.dateCreated}}</p>
 
       <hr />

--- a/views/partials/publications/body/view.hbs
+++ b/views/partials/publications/body/view.hbs
@@ -4,7 +4,7 @@
 
       <h1><span class="text-accent">{{publication.type}}:</span> {{publication.title}}</h1>
 
-      <p>Authors: {{publication.authors}}</p>
+      <p>Authors: {{> authorsList authors=publication.authors }}</p>
       <p>Date added: {{formatDate publication.dateCreated}}</p>
 
       <hr />

--- a/views/publications/search.hbs
+++ b/views/publications/search.hbs
@@ -89,9 +89,8 @@
 
             <!-- <blockquote>{{{markHits this.summary ../query.phrase}}}</blockquote> -->
 
-            <p>{{this.authors}}</p>
-
             <ul class="list-unstyled small">
+              <li><strong>Authors:</strong>{{> authorsList authors=this.authors}}</li>
               <li><strong>Parent publication:</strong> {{this.parentPublication}} &nbsp;</li>
               <li><strong>Part of problem:</strong> {{this.parentProblem}} &nbsp;</li>
               <li><strong>Date added:</strong> {{formatDate this.dateCreated}} &nbsp;</li>


### PR DESCRIPTION
## https://wingravity.atlassian.net/browse/OC-62


## Summary
- Created a new partial called `authorsList`
- The search results contain the `authors` list
- The publication view contains the `authors` list

## Preview
<table>
<tr><th>Publication View</th><th>Publications search</th></tr>
<tr><td><img src="https://user-images.githubusercontent.com/32541444/68856084-4fd8a980-06e8-11ea-8b89-16ca18b1394a.png" /></td><td><img src="https://user-images.githubusercontent.com/32541444/68856083-4fd8a980-06e8-11ea-881a-d14659be2b77.png" /></td>

</tr>
</table>

## Note
The base of this PR is #4, since it's relying on a few changes that are present in that branch. This one should be merged first, and #4 afterwards.
